### PR TITLE
Cluster map

### DIFF
--- a/models/campground.js
+++ b/models/campground.js
@@ -12,33 +12,46 @@ ImageSchema.virtual("thumbnail").get(function () {
     return this.url.replace("/upload", "/upload/w_200");
 });
 
-const CampgroundSchema = new Schema({
-    title: String,
-    images: [ImageSchema],
-    geometry: {
-        type: {
-            type: String,
-            enum: ["Point"], 
-            required: true
+// This allow to add the CampgroundSchema properties
+const opts = { toJSON: { virtuals: true } };
+
+const CampgroundSchema = new Schema(
+    {
+        title: String,
+        images: [ImageSchema],
+        geometry: {
+            type: {
+                type: String,
+                enum: ["Point"],
+                required: true
+            },
+            coordinates: {
+                type: [Number],
+                required: true
+            }
         },
-        coordinates: {
-            type: [Number],
-            required: true
-        }
-    },
-    price: Number,
-    description: String,
-    location: String,
-    author: {
-        type: Schema.Types.ObjectId,
-        ref: "User"
-    },
-    reviews: [
-        {
+        price: Number,
+        description: String,
+        location: String,
+        author: {
             type: Schema.Types.ObjectId,
-            ref: "Review"
-        }
-    ]
+            ref: "User"
+        },
+        reviews: [
+            {
+                type: Schema.Types.ObjectId,
+                ref: "Review"
+            }
+        ]
+    },
+    opts
+);
+
+CampgroundSchema.virtual("properties.popUpMarkup").get(function () {
+    return `
+    <strong><a href="/campgrounds/${this._id}">${this.title}</a></strong>
+    <p>${this.description.substring(0, 20)}...</p>
+    `;
 });
 
 // DELETE ALL ASSOCCIATED REVIEWS WITH A CAMPGROUND

--- a/public/javascripts/clusterMap.js
+++ b/public/javascripts/clusterMap.js
@@ -10,7 +10,7 @@ map.on("load", function () {
     // Add a new source from our GeoJSON data and
     // set the 'cluster' option to true. GL-JS will
     // add the point_count property to your source data.
-    map.addSource("earthquakes", {
+    map.addSource("campgrounds", {
         type: "geojson",
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
         // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
@@ -23,7 +23,7 @@ map.on("load", function () {
     map.addLayer({
         id: "clusters",
         type: "circle",
-        source: "earthquakes",
+        source: "campgrounds",
         filter: ["has", "point_count"],
         paint: {
             // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
@@ -55,7 +55,7 @@ map.on("load", function () {
     map.addLayer({
         id: "cluster-count",
         type: "symbol",
-        source: "earthquakes",
+        source: "campgrounds",
         filter: ["has", "point_count"],
         layout: {
             "text-field": "{point_count_abbreviated}",
@@ -67,7 +67,7 @@ map.on("load", function () {
     map.addLayer({
         id: "unclustered-point",
         type: "circle",
-        source: "earthquakes",
+        source: "campgrounds",
         filter: ["!", ["has", "point_count"]],
         paint: {
             "circle-color": "#11b4da",
@@ -83,7 +83,7 @@ map.on("load", function () {
             layers: ["clusters"]
         });
         var clusterId = features[0].properties.cluster_id;
-        map.getSource("earthquakes").getClusterExpansionZoom(
+        map.getSource("campgrounds").getClusterExpansionZoom(
             clusterId,
             function (err, zoom) {
                 if (err) return;

--- a/public/javascripts/clusterMap.js
+++ b/public/javascripts/clusterMap.js
@@ -14,7 +14,7 @@ map.on("load", function () {
         type: "geojson",
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
         // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
-        data: "https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
+        data: campgrounds,
         cluster: true,
         clusterMaxZoom: 14, // Max zoom to cluster points on
         clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)

--- a/public/javascripts/clusterMap.js
+++ b/public/javascripts/clusterMap.js
@@ -1,5 +1,5 @@
 mapboxgl.accessToken = mapboxToken;
-var map = new mapboxgl.Map({
+const map = new mapboxgl.Map({
     container: "map",
     style: "mapbox://styles/mapbox/light-v10",
     center: [-103.59179687498357, 40.66995747013945],
@@ -79,10 +79,10 @@ map.on("load", function () {
 
     // inspect a cluster on click
     map.on("click", "clusters", function (e) {
-        var features = map.queryRenderedFeatures(e.point, {
+        const features = map.queryRenderedFeatures(e.point, {
             layers: ["clusters"]
         });
-        var clusterId = features[0].properties.cluster_id;
+        const clusterId = features[0].properties.cluster_id;
         map.getSource("campgrounds").getClusterExpansionZoom(
             clusterId,
             function (err, zoom) {
@@ -101,15 +101,8 @@ map.on("load", function () {
     // the location of the feature, with
     // description HTML from its properties.
     map.on("click", "unclustered-point", function (e) {
-        var coordinates = e.features[0].geometry.coordinates.slice();
-        var mag = e.features[0].properties.mag;
-        var tsunami;
-
-        if (e.features[0].properties.tsunami === 1) {
-            tsunami = "yes";
-        } else {
-            tsunami = "no";
-        }
+        const { popUpMarkup } = e.features[0].properties;
+        const coordinates = e.features[0].geometry.coordinates.slice();
 
         // Ensure that if the map is zoomed out such that
         // multiple copies of the feature are visible, the
@@ -120,9 +113,7 @@ map.on("load", function () {
 
         new mapboxgl.Popup()
             .setLngLat(coordinates)
-            .setHTML(
-                "magnitude: " + mag + "<br>Was there a tsunami?: " + tsunami
-            )
+            .setHTML(popUpMarkup)
             .addTo(map);
     });
 

--- a/public/javascripts/clusterMap.js
+++ b/public/javascripts/clusterMap.js
@@ -1,0 +1,135 @@
+mapboxgl.accessToken = mapboxToken;
+var map = new mapboxgl.Map({
+    container: "map",
+    style: "mapbox://styles/mapbox/dark-v10",
+    center: [-103.59179687498357, 40.66995747013945],
+    zoom: 3
+});
+
+map.on("load", function () {
+    // Add a new source from our GeoJSON data and
+    // set the 'cluster' option to true. GL-JS will
+    // add the point_count property to your source data.
+    map.addSource("earthquakes", {
+        type: "geojson",
+        // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
+        // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
+        data: "https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
+        cluster: true,
+        clusterMaxZoom: 14, // Max zoom to cluster points on
+        clusterRadius: 50 // Radius of each cluster when clustering points (defaults to 50)
+    });
+
+    map.addLayer({
+        id: "clusters",
+        type: "circle",
+        source: "earthquakes",
+        filter: ["has", "point_count"],
+        paint: {
+            // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
+            // with three steps to implement three types of circles:
+            //   * Blue, 20px circles when point count is less than 100
+            //   * Yellow, 30px circles when point count is between 100 and 750
+            //   * Pink, 40px circles when point count is greater than or equal to 750
+            "circle-color": [
+                "step",
+                ["get", "point_count"],
+                "#51bbd6",
+                100,
+                "#f1f075",
+                750,
+                "#f28cb1"
+            ],
+            "circle-radius": [
+                "step",
+                ["get", "point_count"],
+                20,
+                100,
+                30,
+                750,
+                40
+            ]
+        }
+    });
+
+    map.addLayer({
+        id: "cluster-count",
+        type: "symbol",
+        source: "earthquakes",
+        filter: ["has", "point_count"],
+        layout: {
+            "text-field": "{point_count_abbreviated}",
+            "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+            "text-size": 12
+        }
+    });
+
+    map.addLayer({
+        id: "unclustered-point",
+        type: "circle",
+        source: "earthquakes",
+        filter: ["!", ["has", "point_count"]],
+        paint: {
+            "circle-color": "#11b4da",
+            "circle-radius": 4,
+            "circle-stroke-width": 1,
+            "circle-stroke-color": "#fff"
+        }
+    });
+
+    // inspect a cluster on click
+    map.on("click", "clusters", function (e) {
+        var features = map.queryRenderedFeatures(e.point, {
+            layers: ["clusters"]
+        });
+        var clusterId = features[0].properties.cluster_id;
+        map.getSource("earthquakes").getClusterExpansionZoom(
+            clusterId,
+            function (err, zoom) {
+                if (err) return;
+
+                map.easeTo({
+                    center: features[0].geometry.coordinates,
+                    zoom: zoom
+                });
+            }
+        );
+    });
+
+    // When a click event occurs on a feature in
+    // the unclustered-point layer, open a popup at
+    // the location of the feature, with
+    // description HTML from its properties.
+    map.on("click", "unclustered-point", function (e) {
+        var coordinates = e.features[0].geometry.coordinates.slice();
+        var mag = e.features[0].properties.mag;
+        var tsunami;
+
+        if (e.features[0].properties.tsunami === 1) {
+            tsunami = "yes";
+        } else {
+            tsunami = "no";
+        }
+
+        // Ensure that if the map is zoomed out such that
+        // multiple copies of the feature are visible, the
+        // popup appears over the copy being pointed to.
+        while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+            coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+        }
+
+        new mapboxgl.Popup()
+            .setLngLat(coordinates)
+            .setHTML(
+                "magnitude: " + mag + "<br>Was there a tsunami?: " + tsunami
+            )
+            .addTo(map);
+    });
+
+    map.on("mouseenter", "clusters", function () {
+        map.getCanvas().style.cursor = "pointer";
+    });
+    map.on("mouseleave", "clusters", function () {
+        map.getCanvas().style.cursor = "";
+    });
+});

--- a/public/javascripts/clusterMap.js
+++ b/public/javascripts/clusterMap.js
@@ -1,7 +1,7 @@
 mapboxgl.accessToken = mapboxToken;
 var map = new mapboxgl.Map({
     container: "map",
-    style: "mapbox://styles/mapbox/dark-v10",
+    style: "mapbox://styles/mapbox/light-v10",
     center: [-103.59179687498357, 40.66995747013945],
     zoom: 3
 });
@@ -34,20 +34,20 @@ map.on("load", function () {
             "circle-color": [
                 "step",
                 ["get", "point_count"],
-                "#51bbd6",
-                100,
-                "#f1f075",
-                750,
-                "#f28cb1"
+                "#00BCD4",
+                10,
+                "#2196F3",
+                30,
+                "#3F51B5"
             ],
             "circle-radius": [
                 "step",
                 ["get", "point_count"],
+                15,
+                10,
                 20,
-                100,
                 30,
-                750,
-                40
+                25
             ]
         }
     });

--- a/public/javascripts/showPageMap.js
+++ b/public/javascripts/showPageMap.js
@@ -3,7 +3,7 @@ const map = new mapboxgl.Map({
     container: "map", // container ID
     style: "mapbox://styles/mapbox/streets-v11", // style URL
     center: campground.geometry.coordinates, // starting position [lng, lat]
-    zoom: 8 // starting zoom
+    zoom: 10 // starting zoom
 });
 
 new mapboxgl.Marker()

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -21,7 +21,7 @@ const sample = (array) => array[Math.floor(Math.random() * array.length)];
 const seedDB = async () => {
     await Campground.deleteMany({});
 
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 10; i++) {
         const random1000 = Math.floor(Math.random() * 1000);
         const price = Math.floor(Math.random() * 20) + 10;
 
@@ -35,20 +35,19 @@ const seedDB = async () => {
             price,
             geometry: {
                 type: "Point",
-                coordinates: [-66.4623392630918, 18.2213294459009]
+                coordinates: [
+                    cities[random1000].longitude,
+                    cities[random1000].latitude
+                ]
             },
             images: [
                 {
-                    url: "https://res.cloudinary.com/kcruzcloud/image/upload/v1625046291/YelpCamp/hvp9wabo5ffhv8m0hneg.jpg",
-                    filename: "YelpCamp/hvp9wabo5ffhv8m0hneg"
+                    url: "https://res.cloudinary.com/kcruzcloud/image/upload/v1625207955/YelpCamp/sfbfdxsu56fwfs9pi7g0.jpg",
+                    filename: "YelpCamp/sfbfdxsu56fwfs9pi7g0"
                 },
                 {
-                    url: "https://res.cloudinary.com/kcruzcloud/image/upload/v1625046290/YelpCamp/k2e72dmqmlfraovxtpwa.jpg",
-                    filename: "YelpCamp/k2e72dmqmlfraovxtpwa"
-                },
-                {
-                    url: "https://res.cloudinary.com/kcruzcloud/image/upload/v1625046290/YelpCamp/cng63ftajrqusjeupq6t.jpg",
-                    filename: "YelpCamp/cng63ftajrqusjeupq6t"
+                    url: "https://res.cloudinary.com/kcruzcloud/image/upload/v1625207957/YelpCamp/cbycx0qvphh3v9hqcq9n.jpg",
+                    filename: "YelpCamp/cbycx0qvphh3v9hqcq9n"
                 }
             ]
         });

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -21,7 +21,7 @@ const sample = (array) => array[Math.floor(Math.random() * array.length)];
 const seedDB = async () => {
     await Campground.deleteMany({});
 
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 50; i++) {
         const random1000 = Math.floor(Math.random() * 1000);
         const price = Math.floor(Math.random() * 20) + 10;
 

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -21,7 +21,9 @@ const sample = (array) => array[Math.floor(Math.random() * array.length)];
 const seedDB = async () => {
     await Campground.deleteMany({});
 
-    for (let i = 0; i < 50; i++) {
+    
+
+    for (let i = 0; i < 300; i++) {
         const random1000 = Math.floor(Math.random() * 1000);
         const price = Math.floor(Math.random() * 20) + 10;
 

--- a/views/campgrounds/index.ejs
+++ b/views/campgrounds/index.ejs
@@ -31,6 +31,7 @@
 
 <script>
     const mapboxToken = "<%- process.env.MAPBOX_TOKEN %>"
+    const campgrounds = {features: <%- JSON.stringify(campgrounds) %>}
 </script>
 
 <script src="/javascripts/clusterMap.js"></script>

--- a/views/campgrounds/index.ejs
+++ b/views/campgrounds/index.ejs
@@ -1,5 +1,7 @@
 <% layout("/layouts/boilerplate") %>
 
+<div id="map" style="width: 100%; height: 500px"></div>
+
 <h1>All Campgrounds</h1>
 
 <% for (let i = campgrounds.length - 1; i >= 0; i--) { %>
@@ -26,3 +28,9 @@
     </div>
 </div>
 <% } %>
+
+<script>
+    const mapboxToken = "<%- process.env.MAPBOX_TOKEN %>"
+</script>
+
+<script src="/javascripts/clusterMap.js"></script>


### PR DESCRIPTION
### Added the Mapbox GL JS cluster map and modified it to match campgrounds

**Summary:**
- Displayed the cluster map on the index page.
- Reseed the database to include map centering for the specific location of a random city + state.
- Cluster map displays campgrounds locations.
- Generated 300 campgrounds to view on the map.
- Changed the size and color of circles in the map.
- Added custom popups when clicking on the location droplet.